### PR TITLE
fixed RNA STAR aligner source

### DIFF
--- a/tools.yaml
+++ b/tools.yaml
@@ -130,8 +130,8 @@ tools:
   - '7d2252852f96'
   install_resolver_dependencies: false
 
-- name: star
-  owner: sarahinraauzeville
+- name: rgrnastar
+  owner: iuc
   revisions:
   - 'c4fc8ff6e280'
   tool_panel_section_label: "RNA-Seq"


### PR DESCRIPTION
I'm having this error while executing the alignment/mapping job using the current STAR aligner:
`Use of uninitialized value $ENV{"MY_GALAXY_DIR"} in string at /shed_tools/toolshed.g2.bx.psu.edu/repos/sarahinraauzeville/star/c4fc8ff6e280/star/sm_STAR2_V2.pl line 23.
Empty compile time value given to use lib at /shed_tools/toolshed.g2.bx.psu.edu/repos`
I don't know whether rewriting the entry for the STAR tool in our `tools.yaml` solves the issue, but IUC's tools are the recommended choice, therefore this should be changed nonetheless